### PR TITLE
Try to add support to apply DistCache to rhs of HashJoin

### DIFF
--- a/cascading-core/src/main/java/cascading/flow/planner/iso/transformer/ReplaceGraphFactoryBasedTransformer.java
+++ b/cascading-core/src/main/java/cascading/flow/planner/iso/transformer/ReplaceGraphFactoryBasedTransformer.java
@@ -1,0 +1,49 @@
+package cascading.flow.planner.iso.transformer;
+
+import java.util.Set;
+
+import cascading.flow.FlowElement;
+import cascading.flow.planner.graph.ElementGraph;
+import cascading.flow.planner.graph.ElementGraphs;
+import cascading.flow.planner.iso.expression.ElementCapture;
+import cascading.flow.planner.iso.expression.ExpressionGraph;
+import cascading.flow.planner.iso.finder.Match;
+
+/**
+ * GraphTransformer that uses the supplied factory to generate the replacement FlowElement.
+ *
+ * Note: This only works if exactly one FlowElement is being replaced.
+ */
+public class ReplaceGraphFactoryBasedTransformer extends ReplaceGraphTransformer {
+
+  private final String factoryName;
+
+  public ReplaceGraphFactoryBasedTransformer(
+    GraphTransformer graphTransformer,
+    ExpressionGraph filter,
+    String factoryName) {
+
+    super(graphTransformer, filter);
+    this.factoryName = factoryName;
+  }
+
+  @Override
+  protected boolean transformGraphInPlaceUsing(
+    Transformed<ElementGraph> transformed,
+    ElementGraph graph,
+    Match match) {
+
+    Set<FlowElement> captured = match.getCapturedElements(ElementCapture.Primary);
+    if (captured.isEmpty()) {
+      return false;
+    } else if (captured.size() != 1) {
+      throw new IllegalStateException("Expected one, but found multiple flow elements in the match expression: " + captured);
+    } else {
+      FlowElement replace = captured.iterator().next();
+      ElementFactory elementFactory = transformed.getPlannerContext().getElementFactoryFor(factoryName);
+      FlowElement replaceWith = elementFactory.create(graph, replace);
+      ElementGraphs.replaceElementWith(graph, replace, replaceWith);
+      return true;
+    }
+  }
+}

--- a/cascading-core/src/main/java/cascading/flow/planner/rule/transformer/RuleReplaceFactoryBasedTransformer.java
+++ b/cascading-core/src/main/java/cascading/flow/planner/rule/transformer/RuleReplaceFactoryBasedTransformer.java
@@ -1,0 +1,34 @@
+package cascading.flow.planner.rule.transformer;
+
+import cascading.flow.planner.iso.transformer.ReplaceGraphFactoryBasedTransformer;
+import cascading.flow.planner.rule.PlanPhase;
+import cascading.flow.planner.rule.RuleExpression;
+import cascading.flow.planner.rule.RuleTransformer;
+
+/**
+ * RuleTransformer that uses the supplied expression to fetch the FlowElement to replace.
+ * The replacement FlowElement is created using the supplied factory.
+ */
+public class RuleReplaceFactoryBasedTransformer extends RuleTransformer {
+
+  public RuleReplaceFactoryBasedTransformer(
+    PlanPhase phase,
+    RuleExpression ruleExpression,
+    String factoryName) {
+
+    super(phase, ruleExpression);
+
+    // the way we've set up our HashJoinExpression, we should have the contractedTransformer
+    // set up but not the subGraph transformer
+    if (subGraphTransformer != null) {
+      graphTransformer = new ReplaceGraphFactoryBasedTransformer(subGraphTransformer,
+        ruleExpression.getMatchExpression(), factoryName);
+    } else if (contractedTransformer != null) {
+      graphTransformer = new ReplaceGraphFactoryBasedTransformer(contractedTransformer,
+        ruleExpression.getMatchExpression(), factoryName);
+    } else {
+      graphTransformer = new ReplaceGraphFactoryBasedTransformer(null,
+        ruleExpression.getMatchExpression(), factoryName);
+    }
+  }
+}

--- a/cascading-hadoop/src/main/shared-mr1/cascading/flow/hadoop/planner/HadoopPlanner.java
+++ b/cascading-hadoop/src/main/shared-mr1/cascading/flow/hadoop/planner/HadoopPlanner.java
@@ -186,8 +186,7 @@ public class HadoopPlanner extends FlowPlanner<HadoopFlow, JobConf>
 
     ruleRegistry.addDefaultElementFactory( IntermediateTapElementFactory.TEMP_TAP, new TempTapElementFactory() );
 
-    // disabled by default
-    // ruleRegistry.addDefaultElementFactory( BalanceHashJoinDistCacheTransformer.DIST_CACHE_TAP, new DistCacheTapElementFactory());
+    ruleRegistry.addDefaultElementFactory( BalanceHashJoinDistCacheTransformer.DIST_CACHE_TAP, new DistCacheTapElementFactory());
     }
 
   protected void checkPlatform( Configuration conf )

--- a/cascading-hadoop/src/main/shared-mr1/cascading/flow/hadoop/planner/MapReduceHadoopRuleRegistry.java
+++ b/cascading-hadoop/src/main/shared-mr1/cascading/flow/hadoop/planner/MapReduceHadoopRuleRegistry.java
@@ -116,6 +116,7 @@ public class MapReduceHadoopRuleRegistry extends RuleRegistry
 
     // enable when GraphFinder supports captured edges
 //    addRule( new RemoveStreamedBranchTransformer() );
-
+    // disabled by default
+    //  addRule( new BalanceHashJoinDistCacheTransformer() );
     }
   }

--- a/cascading-hadoop/src/main/shared-mr1/cascading/flow/hadoop/planner/MapReduceHadoopRuleRegistry.java
+++ b/cascading-hadoop/src/main/shared-mr1/cascading/flow/hadoop/planner/MapReduceHadoopRuleRegistry.java
@@ -29,6 +29,7 @@ import cascading.flow.hadoop.planner.rule.partitioner.StreamedAccumulatedTapsPip
 import cascading.flow.hadoop.planner.rule.partitioner.StreamedOnlySourcesPipelinePartitioner;
 import cascading.flow.hadoop.planner.rule.partitioner.StreamedSelfJoinSourcesPipelinePartitioner;
 import cascading.flow.hadoop.planner.rule.partitioner.TapGroupTapStepPartitioner;
+import cascading.flow.hadoop.planner.rule.transformer.BalanceHashJoinDistCacheTransformer;
 import cascading.flow.hadoop.planner.rule.transformer.RemoveMalformedHashJoinPipelineTransformer;
 import cascading.flow.hadoop.planner.rule.transformer.TapBalanceCheckpointTransformer;
 import cascading.flow.hadoop.planner.rule.transformer.TapBalanceGroupBlockingHashJoinTransformer;
@@ -116,7 +117,6 @@ public class MapReduceHadoopRuleRegistry extends RuleRegistry
 
     // enable when GraphFinder supports captured edges
 //    addRule( new RemoveStreamedBranchTransformer() );
-    // disabled by default
-    //  addRule( new BalanceHashJoinDistCacheTransformer() );
+    addRule( new BalanceHashJoinDistCacheTransformer() );
     }
   }

--- a/cascading-hadoop/src/main/shared/cascading/flow/hadoop/planner/rule/expression/BalanceHashJoinExpression.java
+++ b/cascading-hadoop/src/main/shared/cascading/flow/hadoop/planner/rule/expression/BalanceHashJoinExpression.java
@@ -1,0 +1,25 @@
+package cascading.flow.hadoop.planner.rule.expression;
+
+import cascading.flow.planner.iso.expression.ElementCapture;
+import cascading.flow.planner.iso.expression.ExpressionGraph;
+import cascading.flow.planner.iso.expression.FlowElementExpression;
+import cascading.flow.planner.iso.expression.PathScopeExpression;
+import cascading.flow.planner.rule.RuleExpression;
+import cascading.flow.planner.rule.expressiongraph.SyncPipeExpressionGraph;
+import cascading.pipe.HashJoin;
+import cascading.tap.hadoop.Hfs;
+
+public class BalanceHashJoinExpression extends RuleExpression {
+
+  public BalanceHashJoinExpression() {
+    super(
+      new SyncPipeExpressionGraph(),
+      new ExpressionGraph()
+        .arc(
+          new FlowElementExpression(ElementCapture.Primary, Hfs.class),
+          PathScopeExpression.BLOCKING,
+          new FlowElementExpression(HashJoin.class)
+        )
+    );
+  }
+}

--- a/cascading-hadoop/src/main/shared/cascading/flow/hadoop/planner/rule/transformer/BalanceHashJoinDistCacheTransformer.java
+++ b/cascading-hadoop/src/main/shared/cascading/flow/hadoop/planner/rule/transformer/BalanceHashJoinDistCacheTransformer.java
@@ -1,0 +1,19 @@
+package cascading.flow.hadoop.planner.rule.transformer;
+
+import cascading.flow.hadoop.planner.rule.expression.BalanceHashJoinExpression;
+import cascading.flow.planner.rule.transformer.RuleReplaceFactoryBasedTransformer;
+import static cascading.flow.planner.rule.PlanPhase.BalanceAssembly;
+
+public class BalanceHashJoinDistCacheTransformer extends RuleReplaceFactoryBasedTransformer {
+
+  /* Key used for registering DistCacheTapElementFactory */
+  public static String DIST_CACHE_TAP = "cascading.registry.tap.distcache";
+
+  public BalanceHashJoinDistCacheTransformer() {
+    super(
+      BalanceAssembly,
+      new BalanceHashJoinExpression(),
+      DIST_CACHE_TAP
+    );
+  }
+}

--- a/cascading-hadoop/src/test/shared/cascading/flow/hadoop/ExpressionFinderPlatformTest.java
+++ b/cascading-hadoop/src/test/shared/cascading/flow/hadoop/ExpressionFinderPlatformTest.java
@@ -1,0 +1,124 @@
+package cascading.flow.hadoop;
+
+import cascading.PlatformTestCase;
+import cascading.flow.hadoop.planner.rule.expression.BalanceHashJoinExpression;
+import cascading.flow.iso.NonTap;
+import cascading.flow.planner.graph.ElementGraph;
+import cascading.flow.planner.graph.FlowElementGraph;
+import cascading.flow.planner.iso.finder.GraphFinder;
+import cascading.flow.planner.iso.finder.Match;
+import cascading.flow.planner.iso.transformer.ContractedTransformer;
+import cascading.operation.Function;
+import cascading.operation.regex.RegexSplitter;
+import cascading.pipe.Each;
+import cascading.pipe.HashJoin;
+import cascading.pipe.Pipe;
+import cascading.platform.TestPlatform;
+import cascading.tap.SinkMode;
+import cascading.tap.Tap;
+import cascading.tuple.Fields;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static data.InputData.inputFileLower;
+import static data.InputData.inputFileUpper;
+
+public class ExpressionFinderPlatformTest extends PlatformTestCase {
+
+    // test HashJoin graph with a rhs which is a Hfs
+    public static class HashJoinGraphHfsRHS extends FlowElementGraph
+    {
+        public HashJoinGraphHfsRHS(TestPlatform platform, String outputPath) throws Exception
+        {
+            platform.copyFromLocal( inputFileLower );
+            platform.copyFromLocal( inputFileUpper );
+
+            Tap sourceLower = platform.getTextFile( new Fields( "offset", "line" ), inputFileLower );
+            Tap sourceUpper = platform.getTextFile( new Fields( "offset", "line" ), inputFileUpper );
+
+            Map<String, Tap> sources = new HashMap<>();
+
+            sources.put( "lower", sourceLower );
+            sources.put( "upper", sourceUpper );
+
+            Function splitter = new RegexSplitter( new Fields( "num", "char" ), " " );
+
+            Pipe pipeLower = new Each( new Pipe( "lower" ), new Fields( "line" ), splitter );
+            Pipe pipeUpper = new Each( new Pipe( "upper" ), new Fields( "line" ), splitter );
+
+            Pipe splice = new HashJoin( pipeLower, new Fields( "num" ), pipeUpper, new Fields( "num" ), Fields.size( 4 ) );
+
+            Tap sink = platform.getTextFile( new Fields( "line" ), outputPath, SinkMode.REPLACE );
+            Map<String, Tap> sinks = new HashMap<>();
+            sinks.put(splice.getName(), sink);
+
+            initialize( sources, sinks, splice );
+        }
+    }
+
+    // test HashJoin graph with a rhs which is a Hfs
+    public static class HashJoinGraphNonTapRHS extends FlowElementGraph
+    {
+        public HashJoinGraphNonTapRHS(TestPlatform platform, String outputPath) throws Exception
+        {
+            platform.copyFromLocal( inputFileLower );
+            platform.copyFromLocal( inputFileUpper );
+
+            Tap sourceLower = new NonTap( new Fields( "offset", "line" ));
+            Tap sourceUpper = new NonTap( new Fields( "offset", "line" ));
+
+            Map<String, Tap> sources = new HashMap<>();
+
+            sources.put( "lower", sourceLower );
+            sources.put( "upper", sourceUpper );
+
+            Function splitter = new RegexSplitter( new Fields( "num", "char" ), " " );
+
+            Pipe pipeLower = new Each( new Pipe( "lower" ), new Fields( "line" ), splitter );
+            Pipe pipeUpper = new Each( new Pipe( "upper" ), new Fields( "line" ), splitter );
+
+            Pipe splice = new HashJoin( pipeLower, new Fields( "num" ), pipeUpper, new Fields( "num" ), Fields.size( 4 ) );
+
+            Tap sink = platform.getTextFile( new Fields( "line" ), outputPath, SinkMode.REPLACE );
+            Map<String, Tap> sinks = new HashMap<>();
+            sinks.put(splice.getName(), sink);
+
+            initialize( sources, sinks, splice );
+        }
+    }
+
+    // test to see if we're able to match a graph that has a hashJoin rhs that is a Hfs
+    @Test
+    public void testFindHfsRHS() throws Exception
+    {
+        ElementGraph graph = new HashJoinGraphHfsRHS(getPlatform(), getOutputPath());
+        BalanceHashJoinExpression hashJoinExpression = new BalanceHashJoinExpression();
+
+        graph = new ContractedTransformer( hashJoinExpression.getContractionExpression() ).transform( graph ).getEndGraph();
+
+        GraphFinder graphFinder = new GraphFinder( hashJoinExpression.getMatchExpression() );
+
+        Match match = graphFinder.findFirstMatch( graph );
+
+        Assert.assertTrue(match.foundMatch());
+    }
+
+    // test to see if we end up skipping to match a graph that has a hashJoin rhs that isn't a hfs
+    @Test
+    public void testFailedFindNonHfsRHS() throws Exception
+    {
+        ElementGraph graph = new HashJoinGraphNonTapRHS(getPlatform(), getOutputPath());
+        BalanceHashJoinExpression hashJoinExpression = new BalanceHashJoinExpression();
+
+        graph = new ContractedTransformer( hashJoinExpression.getContractionExpression() ).transform( graph ).getEndGraph();
+
+        GraphFinder graphFinder = new GraphFinder( hashJoinExpression.getMatchExpression() );
+
+        Match match = graphFinder.findFirstMatch( graph );
+
+        Assert.assertFalse(match.foundMatch());
+    }
+}


### PR DESCRIPTION
Cutting a PR against our internal fork for the same changes as: https://github.com/cwensel/cascading/pull/55 so that we can proceed with an internal release. The only additional change on top of the external PR is to turn on the hash join dist cache rule by default. 
